### PR TITLE
feature: OpenWeatherMap API 연동

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,9 @@
 import os
 import json
 from flask import Flask, jsonify
-from flask_cors import CORS     #1. CORS import
-# weather_6thWEEK.py의 주요 함수 import
+from flask_cors import CORS
+
+# 기상청 API 관련 함수들
 from API.weather_6thWeek import (
     get_short_term_forecast,
     get_mid_term_forecast,
@@ -13,23 +14,39 @@ from API.weather_6thWeek import (
     process_weather_alerts
 )
 
-app = Flask(__name__)
-CORS(app)  # CORS 허용
+# OpenWeather API 관련 함수들
+from API.weather_0616 import (
+    get_weather_data as get_openweather_data,
+    process_data as process_openweather_data
+)
 
+app = Flask(__name__)
+CORS(app)
+
+# -------------------- 설정 --------------------
 # 개발 모드 설정 (True -> dummy_data.json 사용, False -> 실제 API 호출)
-IS_DEV_MODE = False
+IS_DEV_MODE = False     # ← True로 바꾸면 개발 모드
+
+# 데이터 소스 선택 ("KMA" -> 기상청 API 사용, "OPENWEATHER" -> OpenWeather API 사용)
+SOURCE_MODE = "OPENWEATHER"  # ← "KMA"로 바꾸면 기상청 API 사용
+# ---------------------------------------------
 
 @app.route('/api/weather')
 def get_weather():
     try:
         if IS_DEV_MODE:
-            # --- 개발 모드 ---
-            # dummy_data.json 위치가 API 폴더 안이므로 경로 수정
+            # --- 개발 모드 (dummy_data.json 사용) ---
             dummy_path = os.path.join(os.path.dirname(__file__), '..', 'API', 'dummy_data.json')
             with open(dummy_path, 'r', encoding='utf-8') as f:
                 final_data = json.load(f)
-        else:
-            # --- 실서버 모드 ---
+
+        elif SOURCE_MODE.upper() == "OPENWEATHER":
+            # --- OpenWeather API 사용 ---
+            raw_data = get_openweather_data()
+            final_data = process_openweather_data(raw_data)
+
+        elif SOURCE_MODE.upper() == "KMA":
+            # --- 기상청(KMA) API 사용 ---
             short_term_raw = get_short_term_forecast()
             current_weather = process_short_term_for_current(short_term_raw)
             weekly_short_term = process_short_term_for_weekly(short_term_raw)
@@ -46,6 +63,9 @@ def get_weather():
                 "weather_alerts": weather_alerts
             }
 
+        else:
+            return jsonify({"error": f"알 수 없는 SOURCE_MODE 설정: {SOURCE_MODE}"}), 400
+
         return jsonify(final_data)
 
     except Exception as e:
@@ -54,6 +74,10 @@ def get_weather():
 
 
 if __name__ == '__main__':
-    mode = "개발 모드(dummy data)" if IS_DEV_MODE else "실서버 모드(API 호출)"
+    mode = (
+        "개발 모드(dummy data)"
+        if IS_DEV_MODE
+        else f"실서버 모드 ({'OpenWeather' if SOURCE_MODE == 'OPENWEATHER' else 'KMA'})"
+    )
     print(f"--- 서버 실행: {mode} ---")
     app.run(debug=True)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
#39 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
1. OpenWeatherMap API 연동
2. 기상청 API를 사용할것인지 OpenWeatherMap API를 사용할것인지 선택할수있는 기능 구현

## #️⃣ 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

이전에 했던 방식으로 서버를열고 http://127.0.0.1:5000/api/weather 를 들어갔을때 잘 열리는지 테스트 해주시면 감사하겠습니다!

## 논의하고 싶은 부분
> 논의하고 싶은 부분이 있다면 작성해 주세요.

원래 단기, 중기, 경보를 합쳐서 프론트엔드로 보내기로했었는데 `weather_0616.py` 에서 나뉘어져있어서 어떻게 할것인지.

## 참고사항
[실행방법]
cmd or PowerShell
$ cd C:\Users\WIN\Desktop\오픈소스소프트웨어\todays_sky\todays-sky (todays-sky(main폴더) 를 경로로 설정)
$ venv\Scripts\activate - 가상환경 실행
$ pip install -r requirements.txt - python실행에 필요한 모듈 설치 (처음 실행할 경우만 사용)
$ python -m backend.app - flask 서버 실행
Running on http://127.0.0.1:5000/ - IP주소가 뜨면 성공!
서버 가동 후 브라우저에서 테스트
http://127.0.0.1:5000/api/weather

cmd or PowerShell
$ ctrl + c (서버 종료)