### PR TITLE
feature: 1시간 단위 기온 데이터 구현

### DIFF
--- a/API/weather_0616.py
+++ b/API/weather_0616.py
@@ -7,11 +7,11 @@ from dotenv import load_dotenv
 load_dotenv()
 API_KEY = os.getenv("OPENWEATHER_API_KEY")
 
-#대연동의 좌표
-LAT = 35.1384
-LON = 129.1066
+# 도시 검색 기능 추가 전까지 임시로 사용되는 좌표
+LAT = 35.1384  # 부산 대연동 위도
+LON = 129.1066 # 부산 대연동 경도
 
-
+# OpenWeatherMap 날씨 코드 -> 한국어 번역 딕셔너리
 weather_translate = {
     "Clear": "맑음",
     "Clouds": "구름많음",
@@ -40,7 +40,10 @@ aqi_translate = {
 }
 
 def get_weather_data(lat=LAT, lon=LON):
-    """날씨 (One Call API 3.0) 데이터를 가져옵니다."""
+    """
+    날씨 (One Call API 3.0) 데이터를 가져옵니다. 
+    시간별 데이터(hourly)를 포함하도록 exclude 파라미터를 수정했습니다.
+    """
     url = "https://api.openweathermap.org/data/3.0/onecall"
     params = {
         "lat": lat,
@@ -48,7 +51,8 @@ def get_weather_data(lat=LAT, lon=LON):
         "appid": API_KEY,
         "units": "metric",
         "lang": "kr",
-        "exclude": "minutely,hourly"
+        # 'hourly'를 제외 목록에서 제거하여 1시간 단위 예보 데이터를 포함합니다.
+        "exclude": "minutely"
     }
     res = requests.get(url, params=params, timeout=10)
     res.raise_for_status()
@@ -66,22 +70,36 @@ def get_air_pollution_data(lat=LAT, lon=LON):
     res.raise_for_status()
     return res.json()
 
+# 새롭게 추가된 함수
+def process_hourly_data(data):
+    """시간별 기온 데이터를 처리하여 그래프 표기용 리스트를 반환합니다."""
+    hourly_forecast = []
+    # 'hourly' 배열은 기본적으로 48시간 예보를 포함합니다.
+    hourly_list = data.get("hourly", []) 
+    
+    # 예시로 24시간 동안의 데이터를 추출합니다. (48시간 모두 사용 가능)
+    for item in hourly_list[:24]: 
+        dt = datetime.fromtimestamp(item.get("dt"))
+        hourly_forecast.append({
+            "time": dt.strftime("%H:%M"),  # 시간 (예: "09:00")
+            "temp": round(item.get("temp", 0), 1),  # 기온
+        })
+    return hourly_forecast
+
 def process_data(data):
     """One Call API 데이터(날씨, 주간예보, 특보)를 처리합니다."""
     curr = data.get("current", {})
     daily = data.get("daily", [])
 
-    # 1. 현재 날씨 (Daily[0]에서 가져옴)
+    # 1. 현재 날씨
     weather = curr.get("weather", [{}])[0]
     sky = weather_translate.get(weather.get("main"), weather.get("description", "정보없음"))
     temperature = curr.get("temp")
     humidity = curr.get("humidity")
     
-    # daily[0]는 현재 날짜의 예보입니다.
     temp_min = daily[0].get("temp", {}).get("min") if daily else None
     temp_max = daily[0].get("temp", {}).get("max") if daily else None
     
-    # 강수/강설 유형 판단
     weather_id = weather.get("id", 0)
     rain = curr.get("rain")
     snow = curr.get("snow")
@@ -108,7 +126,6 @@ def process_data(data):
     # 2. 주간 예보 (내일부터 6일간의 예보)
     days_of_week = ['월', '화', '수', '목', '금', '토', '일']
     weekly_forecast = []
-    # daily[1:7] -> 내일부터 6일간의 데이터
     for day in daily[1:7]: 
         dt = datetime.fromtimestamp(day.get("dt"))
         day_of_week = f"{days_of_week[dt.weekday()]}요일"
@@ -164,13 +181,10 @@ def process_air_pollution_data(data):
     aqi_value = current_aqi.get("main", {}).get("aqi")
 
     return {
-        # 대기질 지수 (Air Quality Index, 1=좋음, 5=위험)
         "aqi": str(aqi_value) if aqi_value else "정보없음",
         "aqi_status": aqi_translate.get(aqi_value, "정보없음"),
-        # 미세먼지 농도 (단위: $\mu g/m^3$)
         "pm2_5": str(round(components.get("pm2_5", 0), 2)),
         "pm10": str(round(components.get("pm10", 0), 2)),
-        # 다른 오염 물질: CO, NO, NO2, O3, SO2, NH3
         "co": str(round(components.get("co", 0), 2)),
         "no2": str(round(components.get("no2", 0), 2)),
     }
@@ -179,12 +193,15 @@ def process_air_pollution_data(data):
 if __name__ == "__main__":
     weather_data = get_weather_data()
     result = process_data(weather_data)
+    
+    # 4. 시간별 기온 데이터 처리 및 통합
+    hourly_result = process_hourly_data(weather_data)
+    result["hourly_forecast"] = hourly_result
 
-    # 2. 미세먼지 데이터 가져오기 및 처리
+    # 5. 미세먼지 데이터 가져오기 및 처리
     try:
         pollution_data = get_air_pollution_data()
         air_pollution_result = process_air_pollution_data(pollution_data)
-        # 최종 결과에 통합
         result["air_pollution"] = air_pollution_result
     except requests.exceptions.HTTPError as e:
         print(f"Error fetching air pollution data: {e}. Check your API key and permissions.")

--- a/API/weather_0616.py
+++ b/API/weather_0616.py
@@ -13,6 +13,7 @@ LON = 129.1066 # 부산 대연동 경도
 
 # OpenWeatherMap 날씨 코드 -> 한국어 번역 딕셔너리
 weather_translate = {
+    # ... (생략: 기존 코드와 동일)
     "Clear": "맑음",
     "Clouds": "구름많음",
     "Rain": "비",
@@ -30,20 +31,54 @@ weather_translate = {
     "Tornado": "토네이도",
 }
 
-# 대기질 지수(AQI)를 한국어 상태로 변환하는 딕셔너리
-aqi_translate = {
-    1: "좋음",
-    2: "보통",
-    3: "나쁨",
-    4: "매우 나쁨",
-    5: "위험",
+# ⚠️ AQI 5단계 기준 딕셔너리(aqi_translate)는 이제 사용되지 않습니다. 
+# 대신 한국 환경부 8단계 기준이 사용됩니다.
+
+# --- [새로 추가된 한국 환경부 8단계 기준] ---
+
+# 한국 환경부 PM2.5 (초미세먼지) 8단계 기준 (단위: $\mu g/m^3$)
+PM25_KOREA_STANDARDS = {
+    '최고': (0, 8),
+    '좋음': (8, 16),
+    '양호': (16, 21),
+    '보통': (21, 36),
+    '나쁨': (36, 76),
+    '상당히 나쁨': (76, 101),
+    '매우 나쁨': (101, 251),
+    '위험': (251, 10000),
 }
 
+# 한국 환경부 PM10 (미세먼지) 8단계 기준 (단위: $\mu g/m^3$)
+PM10_KOREA_STANDARDS = {
+    '최고': (0, 15),
+    '좋음': (15, 31),
+    '양호': (31, 41),
+    '보통': (41, 71),
+    '나쁨': (71, 151),
+    '상당히 나쁨': (151, 201),
+    '매우 나쁨': (201, 301),
+    '위험': (301, 10000),
+}
+
+def get_korea_air_status(value, standards):
+    """주어진 농도 값과 한국 기준 딕셔너리를 사용하여 상태를 반환합니다."""
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        return "정보없음"
+    
+    for status, (min_val, max_val) in standards.items():
+        # OpenWeatherMap 농도가 한국 기준 범위 내에 있는지 확인
+        if min_val <= value < max_val:
+            return status
+    return "정보없음"
+
+# ------------------------------------------------------------------
+# get_weather_data, get_air_pollution_data, process_hourly_data, process_data 함수 생략
+# ------------------------------------------------------------------
+
 def get_weather_data(lat=LAT, lon=LON):
-    """
-    날씨 (One Call API 3.0) 데이터를 가져옵니다. 
-    시간별 데이터(hourly)를 포함하도록 exclude 파라미터를 수정했습니다.
-    """
+    # ... (기존 코드와 동일)
     url = "https://api.openweathermap.org/data/3.0/onecall"
     params = {
         "lat": lat,
@@ -51,7 +86,6 @@ def get_weather_data(lat=LAT, lon=LON):
         "appid": API_KEY,
         "units": "metric",
         "lang": "kr",
-        # 'hourly'를 제외 목록에서 제거하여 1시간 단위 예보 데이터를 포함합니다.
         "exclude": "minutely"
     }
     res = requests.get(url, params=params, timeout=10)
@@ -59,7 +93,7 @@ def get_weather_data(lat=LAT, lon=LON):
     return res.json()
 
 def get_air_pollution_data(lat=LAT, lon=LON):
-    """대기 오염 (Air Pollution API 2.5) 데이터를 가져옵니다."""
+    # ... (기존 코드와 동일)
     url = "http://api.openweathermap.org/data/2.5/air_pollution"
     params = {
         "lat": lat,
@@ -70,36 +104,31 @@ def get_air_pollution_data(lat=LAT, lon=LON):
     res.raise_for_status()
     return res.json()
 
-# 새롭게 추가된 함수
 def process_hourly_data(data):
-    """시간별 기온 데이터를 처리하여 그래프 표기용 리스트를 반환합니다."""
+    # ... (기존 코드와 동일)
     hourly_forecast = []
-    # 'hourly' 배열은 기본적으로 48시간 예보를 포함합니다.
     hourly_list = data.get("hourly", []) 
-    
-    # 예시로 24시간 동안의 데이터를 추출합니다. (48시간 모두 사용 가능)
     for item in hourly_list[:24]: 
         dt = datetime.fromtimestamp(item.get("dt"))
         hourly_forecast.append({
-            "time": dt.strftime("%H:%M"),  # 시간 (예: "09:00")
-            "temp": round(item.get("temp", 0), 1),  # 기온
+            "time": dt.strftime("%H:%M"), 
+            "temp": round(item.get("temp", 0), 1), 
+            "weather_icon": item.get("weather", [{}])[0].get("icon", "")
         })
     return hourly_forecast
 
 def process_data(data):
-    """One Call API 데이터(날씨, 주간예보, 특보)를 처리합니다."""
+    # ... (기존 코드와 동일)
     curr = data.get("current", {})
     daily = data.get("daily", [])
-
+    
     # 1. 현재 날씨
     weather = curr.get("weather", [{}])[0]
     sky = weather_translate.get(weather.get("main"), weather.get("description", "정보없음"))
     temperature = curr.get("temp")
     humidity = curr.get("humidity")
-    
     temp_min = daily[0].get("temp", {}).get("min") if daily else None
     temp_max = daily[0].get("temp", {}).get("max") if daily else None
-    
     weather_id = weather.get("id", 0)
     rain = curr.get("rain")
     snow = curr.get("snow")
@@ -166,25 +195,42 @@ def process_data(data):
     }
 
 def process_air_pollution_data(data):
-    """Air Pollution API 데이터(미세먼지)를 처리합니다."""
+    """
+    Air Pollution API 데이터(미세먼지)를 처리하고, 
+    한국 환경부 8단계 기준 상태를 추가합니다.
+    """
     current_aqi = data.get("list", [{}])[0]
     
     if not current_aqi:
         return {
             "aqi": "정보없음",
-            "aqi_status": "정보없음",
             "pm2_5": "정보없음",
             "pm10": "정보없음",
+            "pm2_5_status_kr": "정보없음",
+            "pm10_status_kr": "정보없음",
         }
 
     components = current_aqi.get("components", {})
+    # OpenWeatherMap AQI (1~5)는 유지하지만, 상태는 한국 기준으로 대체됩니다.
     aqi_value = current_aqi.get("main", {}).get("aqi")
+    
+    # PM 농도 값 추출 (str로 저장)
+    pm2_5_val = str(round(components.get("pm2_5", 0), 2))
+    pm10_val = str(round(components.get("pm10", 0), 2))
 
     return {
-        "aqi": str(aqi_value) if aqi_value else "정보없음",
-        "aqi_status": aqi_translate.get(aqi_value, "정보없음"),
-        "pm2_5": str(round(components.get("pm2_5", 0), 2)),
-        "pm10": str(round(components.get("pm10", 0), 2)),
+        # OpenWeatherMap AQI 값은 유지
+        "aqi": str(aqi_value) if aqi_value else "정보없음", 
+        
+        # 미세먼지 농도 (단위: $\mu g/m^3$)
+        "pm2_5": pm2_5_val,
+        "pm10": pm10_val,
+        
+        # 🆕 한국 환경부 8단계 기준 상태 추가
+        "pm2_5_status_kr": get_korea_air_status(pm2_5_val, PM25_KOREA_STANDARDS),
+        "pm10_status_kr": get_korea_air_status(pm10_val, PM10_KOREA_STANDARDS),
+        
+        # 기타 오염 물질
         "co": str(round(components.get("co", 0), 2)),
         "no2": str(round(components.get("no2", 0), 2)),
     }
@@ -194,11 +240,11 @@ if __name__ == "__main__":
     weather_data = get_weather_data()
     result = process_data(weather_data)
     
-    # 4. 시간별 기온 데이터 처리 및 통합
+    # 시간별 기온 데이터 처리 및 통합
     hourly_result = process_hourly_data(weather_data)
     result["hourly_forecast"] = hourly_result
 
-    # 5. 미세먼지 데이터 가져오기 및 처리
+    # 미세먼지 데이터 가져오기 및 처리
     try:
         pollution_data = get_air_pollution_data()
         air_pollution_result = process_air_pollution_data(pollution_data)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #68  #70

## #️⃣ 작업 내용

데이터 요청 수정: get_weather_data에서 hourly 데이터를 제외하지 않도록 수정했습니다.

새로운 처리 함수 추가: process_hourly_data(data) 함수를 추가하여 48시간 동안의 시간별 기온을 추출합니다.

통합: if name == "main": 블록에서 처리된 시간별 기온 데이터를 최종 결과에 hourly_forecast라는 키로 통합했습니다.

한국형 미세먼지 상태 필드 추가
- 기존에 AQI 5단계로 분류되어 나타나던 미세먼지 정보를 한국의 미세먼지 8단계 기준을 사용하여 PM2.5 및 PM10 농도를 상태(좋음, 보통, 나쁨 등)로 변환하는 함수 추가

## #️⃣ 리뷰 요구사항 (선택)


```python

"hourly_forecast": [
    {
      "time": "01:00",
      "temp": 6.0
    },
    {
      "time": "02:00",
      "temp": 7.3
    },
    {
      "time": "03:00",
      "temp": 8.6
    },
    {
      "time": "04:00",
      "temp": 9.9
    },
    {
      "time": "05:00",
      "temp": 11.1
    }

``` 
이렇게 잘 출력이 되는지 확인부탁드립니다

## 논의하고 싶은 부분 (선택)
> 논의하고 싶은 부분이 있다면 작성해 주세요.

## 참고사항
