### PR TITLE
feature: 기상특보 한글 번역

### DIFF
--- a/frontend/src/pages/WeatherPage.tsx
+++ b/frontend/src/pages/WeatherPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect }from 'react';
 import * as Styled from './WeatherPage.styles';
 import type { WeatherData, DailyForecast } from '../types/weather';
 import { BackgroundKey } from '../utils/BackgroundKey';
+import { translateAlert } from '../utils/translateAlert';
 
 const getIconForSky = (sky: string | undefined): string => {
   if (!sky) return '01d'; // 기본값 (맑음)
@@ -173,12 +174,12 @@ function WeatherPage() {
             <p className="location">Daeyeon-dong, Nam-gu</p>
             <p>{formatCurrentTime(currentTime)}</p>
           </Styled.CurrentInfo>
-          {weather_alerts.length > 0 && !weather_alerts[0].content.includes("발효된 특보가 없습니다") && (
+          {weather_alerts.length > 0 && (
           <Styled.WeatherAlertSection>
             <h3>기상 특보</h3>
             <ul>
               {weather_alerts.map((alert, index) => (
-                <li key={index}>{alert.content}</li>
+                <li key={index}>{translateAlert(alert.content)}</li>
               ))}
             </ul>
           </Styled.WeatherAlertSection>

--- a/frontend/src/utils/translateAlert.ts
+++ b/frontend/src/utils/translateAlert.ts
@@ -1,0 +1,23 @@
+//영어 특보(event) → 한글 번역 테이블
+export const ALERT_TRANSLATIONS: Record<string, string> = {
+  "DryAir Advisory": "건조주의보",
+  "Storm Surge Advisory": "폭풍해일주의보",
+  "Heavy Rain Advisory": "호우주의보",
+  "High Wind Advisory": "강풍주의보",
+  "High Wave Advisory": "풍랑주의보",
+  "Cold Wave Advisory": "한파주의보",
+  "Heavy Snow Advisory": "대설주의보",
+  "Yellow Dust Advisory": "황사주의보",
+  "Typhoon Advisory": "태풍주의보",
+  "Heatwave Advisory": "폭염주의보",
+  "Tsunami Advisory": "해일주의보",
+};
+
+// 특보 텍스트 변환 함수
+export const translateAlert = (event: string): string => {
+  if (!event || event === "None") return "현재 발효된 특보가 없습니다";
+  // 앞에 붙어 있는 "[기상특보]" 같은 패턴을 제거
+  const cleaned = event.replace(/\[.*?\]\s*/g, "");
+
+  return ALERT_TRANSLATIONS[cleaned] || cleaned;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

#92 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

영어로 뜨는 기상특보를 한글로 번역해서 보여주는 기능을 추가했습니다.

영어 특보를 한글로 번역하는 테이블을 따로 관리하기 위해 유틸파일로 `translateAlert.ts`를 만들었습니다.
<img width="495" height="359" alt="image" src="https://github.com/user-attachments/assets/5fb9e89c-577c-4b06-b9dd-716274c85424" />



## #️⃣ 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

특보가 잘 나오는지 확인해주시면 감사하겠습니다!

## 참고사항
- 기상특보 목록
"DryAir Advisory": "건조주의보",
 "Storm Surge Advisory": "폭풍해일주의보",
 "Heavy Rain Advisory": "호우주의보",
 "High Wind Advisory": "강풍주의보",
 "High Wave Advisory": "풍랑주의보",
 "Cold Wave Advisory": "한파주의보",
 "Heavy Snow Advisory": "대설주의보",
 "Yellow Dust Advisory": "황사주의보",
 "Typhoon Advisory": "태풍주의보",
 "Heatwave Advisory": "폭염주의보",
 "Tsunami Advisory": "해일주의보"